### PR TITLE
Add configuration options to Object Detection use-case

### DIFF
--- a/app/src/main/java/com/example/bioniclens/objectrecognition/ObjectGraphic.kt
+++ b/app/src/main/java/com/example/bioniclens/objectrecognition/ObjectGraphic.kt
@@ -15,7 +15,8 @@ import kotlin.math.min
 // Draw the detected object info in preview.
 class ObjectGraphic constructor(
     overlay: GraphicOverlay,
-    private val detectedObject: DetectedObject
+    private val detectedObject: DetectedObject,
+    private val drawTrackingId: Boolean
 ) : Graphic(overlay) {
 
     private val numColors = COLORS.size
@@ -79,6 +80,9 @@ class ObjectGraphic constructor(
         rect.bottom = translateY(rect.bottom)
         canvas.drawRect(rect, boxPaints[colorID])
 
+        if (!drawTrackingId) {
+            yLabelOffset += lineHeight
+        }
         // Draws other object info.
         canvas.drawRect(
             rect.left - STROKE_WIDTH,
@@ -87,13 +91,16 @@ class ObjectGraphic constructor(
             rect.top,
             labelPaints[colorID]
         )
-        yLabelOffset += TEXT_SIZE
-        canvas.drawText(
-            "Tracking ID: " + detectedObject.trackingId,
-            rect.left,
-            rect.top + yLabelOffset,
-            textPaints[colorID]
-        )
+
+        if (drawTrackingId) {
+            yLabelOffset += TEXT_SIZE
+            canvas.drawText(
+                "Tracking ID: " + detectedObject.trackingId,
+                rect.left,
+                rect.top + yLabelOffset,
+                textPaints[colorID]
+            )
+        }
         yLabelOffset += lineHeight
         for (label in detectedObject.labels) {
             canvas.drawText(

--- a/app/src/main/res/layout/activity_obj_recognition.xml
+++ b/app/src/main/res/layout/activity_obj_recognition.xml
@@ -7,6 +7,17 @@
     android:background="@drawable/bg_purple_gradient"
     tools:context=".objectrecognition.ObjRecognitionActivity">
 
+    <Button
+        android:id="@+id/settingsButton"
+        android:layout_width="58dp"
+        android:layout_height="58dp"
+        android:background="@drawable/settings_cog"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.976" />
 
     <androidx.camera.view.PreviewView
         android:id="@+id/viewFinder"
@@ -95,6 +106,73 @@
             android:paddingLeft="30dp"
             android:paddingRight="30dp"
             android:text="@string/selfie_segmentation"
+            android:textColor="@color/white" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayoutSettingsEnable"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <Button
+            android:id="@+id/detection_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:background="@drawable/option_button"
+            android:fontFamily="@font/hammersmith_one_regular"
+            android:paddingLeft="30dp"
+            android:paddingRight="30dp"
+            android:text="@string/obj_det_mode"
+            android:textColor="@color/white" />
+
+        <Button
+            android:id="@+id/object_track"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="30dp"
+            android:background="@drawable/option_button"
+            android:fontFamily="@font/hammersmith_one_regular"
+            android:text="@string/obj_det_multiple_objects"
+            android:textColor="@color/white" />
+
+        <Button
+            android:id="@+id/classify_objects"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="30dp"
+            android:background="@drawable/option_button"
+            android:fontFamily="@font/hammersmith_one_regular"
+            android:text="@string/obj_det_classify"
+            android:textColor="@color/white" />
+
+        <Button
+            android:id="@+id/more_labels"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="30dp"
+            android:background="@drawable/option_button"
+            android:fontFamily="@font/hammersmith_one_regular"
+            android:text="@string/obj_det_increase_labels"
+            android:textColor="@color/white" />
+
+        <Button
+            android:id="@+id/less_labels"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="30dp"
+            android:background="@drawable/option_button"
+            android:fontFamily="@font/hammersmith_one_regular"
+            android:text="@string/obj_det_decrease_labels"
             android:textColor="@color/white" />
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="devanagari_and_latin">Devanagari and Latin</string>
     <string name="translate_to_english">Translate to English</string>
     <string name="translate_to_romanian">Translate to Romanian</string>
+    <string name="obj_det_mode">Single Image Mode</string>
+    <string name="obj_det_multiple_objects">Single Object Detection</string>
+    <string name="obj_det_classify">Turn OFF Classification</string>
+    <string name="obj_det_increase_labels">Show More Labels</string>
+    <string name="obj_det_decrease_labels">Show Less Labels</string>
 </resources>


### PR DESCRIPTION
User can now choose between Single-Image-Mode or Streaming-Mode,
if only the most prominent object should be detected or more (at most 5) objects
should be detected, if object classification should be ON or OFF, and is able to
increase or decrease the number of object labels shown.